### PR TITLE
Update ringdisk logic to support dict and list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ a tool to help us properly boostrap and manage a swift environment.
 
 Sample ring_definition.yml to use SSD for account/container rings and SATA for object ring:
 
+```
 ---
 part_power: 13
 replicas: 3
@@ -23,11 +24,12 @@ zones:
           - sde1
           - sdf1
           - sdg1
-
+```
 
 
 Sample ring_definition.yml where disks belong to all rings:
 
+```
 ---
 part_power: 13
 replicas: 3
@@ -36,14 +38,14 @@ zones:
   z1:
     node1:
       disks:
-        all:
-          - sdb1
-          - sdc1
-          - sdc1
-          - sdd1
-          - sde1
-          - sdf1
-          - sdg1
+        - sdb1
+        - sdc1
+        - sdc1
+        - sdd1
+        - sde1
+        - sdf1
+        - sdg1
+```
 
 license
 =======

--- a/swifttool/client.py
+++ b/swifttool/client.py
@@ -132,13 +132,18 @@ class SwiftRingsDefinition(object):
             commands.append(self._ring_create_command(ringtype, outdir))
             for zone, nodes in self.zones.iteritems():
                 for node, disks in nodes.iteritems():
+                    
                     ringdisks = []
                     # Add all disks designated for ringtype
-                    if ringtype in disks['disks']:
-                        ringdisks += disks['disks'][ringtype]
-                    # Add any disks that will be used for all rings
-                    if 'all' in disks['disks']:
-                        ringdisks = list(set(ringsdisks + disks['disks']['all']))
+                    if isinstance(disks['disks'], dict):
+                        if ringtype in disks['disks']:
+                            ringdisks += disks['disks'][ringtype]
+                        else:
+                            raise Exception("Malformed ring_defintion.yml. "
+                                            "Unknown ringtype: %s" % ringtype)
+                    elif isinstance(disks['disks'], list):
+                        ringdisks = disks['disks']
+                    
                     for disk in ringdisks:
                         match = re.match('(.*)\d+$', disk)
                         blockdev = '/dev/%s' % match.group(1)


### PR DESCRIPTION
We want to be able to qualify which rings get placed on which disks.
This change enables that but also supports backwards compatibility
with all rings being on all data disks.
